### PR TITLE
注册和登陆界面优化

### DIFF
--- a/resources/views/material/auth/login.tpl
+++ b/resources/views/material/auth/login.tpl
@@ -31,7 +31,7 @@
 										<div class="card-main">
 											<div class="card-header">
 												<div class="card-inner">
-													<h1 class="card-heading">登录到用户中心</h1>
+													<h1 class="card-heading style=" text-align:center;">登录到用户中心</h1>
 												</div>
 											</div>
 											<div class="card-inner">

--- a/resources/views/material/auth/login.tpl
+++ b/resources/views/material/auth/login.tpl
@@ -31,7 +31,7 @@
 										<div class="card-main">
 											<div class="card-header">
 												<div class="card-inner">
-													<h1 class="card-heading style=" text-align:center;">登录到用户中心</h1>
+													<h1 class="card-heading style=" text-align:center;font-weight:lighter;">登录到用户中心</h1>
 												</div>
 											</div>
 											<div class="card-inner">

--- a/resources/views/material/auth/login.tpl
+++ b/resources/views/material/auth/login.tpl
@@ -31,7 +31,7 @@
 										<div class="card-main">
 											<div class="card-header">
 												<div class="card-inner">
-													<h1 class="card-heading style=" text-align:center;font-weight:lighter;">登录到用户中心</h1>
+													<h1 class="card-heading" style=" text-align:center;font-weight:bold;">登录到用户中心</h1>
 												</div>
 											</div>
 											<div class="card-inner">

--- a/resources/views/material/auth/register.tpl
+++ b/resources/views/material/auth/register.tpl
@@ -10,7 +10,17 @@
 							<div class="card-main">
 								<div class="card-header">
 									<div class="card-inner">
-										<h1 class="card-heading"><img src="/images/register.jpg" height=100% width=100% /></h1>
+									<!-- 这里可以取消掉注释换logo图。
+									<h1 class="card-heading"><img src="/images/register.jpg" height=100% width=100% /></h1>
+									-->
+									<h1 class="card-heading">
+										<div class="text" style=" text-align:center;">
+											欢迎来到
+										</div>
+										<div class="text" style=" text-align:center;font-weight: bold;">
+											{$config["appName"]}
+										</div>
+									</h1>
 									</div>
 								</div>
 								<div class="card-inner">


### PR DESCRIPTION
登陆界面卡片标题居中、加粗，使其更有标题感。
注册界面卡片标题由图片变更为居中的欢迎语句，第一行为居中的“欢迎来到”，第二行为居中加粗站名。
我不会码网页，只是觉得这样改动会更好看就试着改了。有什么低级错误或者代码功能性冲突请大佬们见谅。