### PR TITLE
新增一键迁移/更新配置

### DIFF
--- a/app/Command/XCat.php
+++ b/app/Command/XCat.php
@@ -84,6 +84,8 @@ class XCat
                 return $this->resetPort();
 			case("resetAllPort"):
                 return $this->resetAllPort();
+			case("migrateConfig"):
+			    return $this->migrateConfig();
             default:
                 return $this->defaultAction();
         }
@@ -91,16 +93,17 @@ class XCat
 
     public function defaultAction()
     {
-        echo "\n用法： php xcat [选项] \n\n";
-		echo "常用选项: \n";
-		echo "  createAdmin - 创建管理员帐号\n";
-		echo "  setTelegram - 设置 Telegram 机器人\n";
-		echo "  cleanRelayRule - 清除所有中转规则\n";
-		echo "  resetPort - 重置单个用户端口\n";
-		echo "  resetAllPort - 重置所有用户端口\n";
-		echo "  initdownload - 下载 SSR 程序至服务器\n";
-		echo "  initQQWry - 下载 IP 解析库 \n";
-		echo "  resetTraffic - 重置所有用户流量\n\n";
+        echo(PHP_EOL."用法： php xcat [选项]".PHP_EOL);
+		echo("常用选项:".PHP_EOL);
+		echo("  createAdmin - 创建管理员帐号".PHP_EOL);
+		echo("  setTelegram - 设置 Telegram 机器人".PHP_EOL);
+		echo("  cleanRelayRule - 清除所有中转规则".PHP_EOL);
+		echo("  resetPort - 重置单个用户端口".PHP_EOL);
+		echo("  resetAllPort - 重置所有用户端口".PHP_EOL);
+		echo("  initdownload - 下载 SSR 程序至服务器".PHP_EOL);
+		echo("  initQQWry - 下载 IP 解析库".PHP_EOL);
+		echo("  resetTraffic - 重置所有用户流量".PHP_EOL);
+		echo("  migrateConfig - 将配置迁移至新配置".PHP_EOL);
     }
 
 	public function resetPort()
@@ -138,6 +141,80 @@ class XCat
             $rule->save();
         }
     }
+
+	public function migrateConfig()
+	{
+	    global $System_Config;
+	    $copy_result=copy(BASE_PATH."/config/.config.php",BASE_PATH."/config/.config.php.bak");
+		if($copy_result==true){
+			echo('备份成功！'.PHP_EOL);
+		}
+		else{
+			echo('备份失败！迁移终止'.PHP_EOL);
+			return false;
+		}
+
+		//将旧config迁移到新config上
+		$config_old=file_get_contents(BASE_PATH."/config/.config.php");
+		$config_new=file_get_contents(BASE_PATH."/config/.config.php.example");
+		$migrated=array();
+		foreach($System_Config as $key => $value_reserve){
+			if($key=='config_migrate_notice'){
+				continue;
+			}
+
+			$regex='/System_Config\[\''.$key.'\'\].*?;/s';
+			$matches_new=array();
+			preg_match($regex,$config_new,$matches_new);
+			if(isset($matches_new[0])==false){
+				echo('配置项：'.$key.' 未能在新config文件中找到，可能已被更名或废弃'.PHP_EOL);
+				continue;
+			}
+
+			$matches_old=array();
+			preg_match($regex,$config_old,$matches_old);
+
+			$config_new=str_replace($matches_new[0],$matches_old[0],$config_new);
+			array_push($migrated,'System_Config[\''.$key.'\']');
+		}
+
+		//检查新增了哪些config
+		$regex_new='/System_Config\[\'.*?\'\]/s';
+		$matches_new_all=array();
+		preg_match_all($regex_new,$config_new,$matches_new_all);
+		$new_all=$matches_new_all[0];
+		$differences=array_diff($new_all,$migrated);
+		foreach($differences as $difference){
+			//裁去首位
+			$difference=substr($difference,15);
+			$difference=substr($difference, 0, -2);
+
+			echo('新增配置项：'.$difference.PHP_EOL);
+		}
+
+		//输出notice
+		$regex_notice='/System_Config\[\'config_migrate_notice\'\].*?(?=\';)/s';
+		$matches_notice=array();
+		preg_match($regex_notice,$config_new,$matches_notice);
+		$notice_new=$matches_notice[0];
+		$notice_new=substr(
+			$notice_new,strpos(
+				$notice_new,'\'',strpos($notice_new,'=') //查找'='之后的第一个'\''，然后substr其后面的notice
+			)+1
+		);
+		echo('以下是迁移附注：');
+		if(isset($System_Config['config_migrate_notice'])==true){
+		    if($System_Config['config_migrate_notice']!=$notice_new){
+			    echo($notice_new);
+			}
+		}
+		else{
+			echo($notice_new);
+		}
+
+		file_put_contents(BASE_PATH."/config/.config.php",$config_new);
+		echo(PHP_EOL.'迁移完成！'.PHP_EOL);
+	}
 
     public function cleanRelayRule()
     {

--- a/app/Controllers/AdminController.php
+++ b/app/Controllers/AdminController.php
@@ -56,6 +56,12 @@ class AdminController extends UserController
         $num = $request->getParam('num');
         $prefix = $request->getParam('prefix');
 
+		if(is_numeric($num)){
+		    $res['ret'] = 0;
+            $res['msg'] = "非法请求";
+            return $response->getBody()->write(json_encode($res));
+		}
+
         if ($request->getParam('uid')!="0") {
             if (strpos($request->getParam('uid'), "@")!=false) {
                 $user=User::where("email", "=", $request->getParam('uid'))->first();

--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -1026,7 +1026,7 @@ class UserController extends BaseController
 	{
 	    $price=Config::get('invite_price');
 		$num=$request->getParam('num');
-		if($price<0||$num<=0){
+		if(is_numeric($num)||$price<0||$num<=0){
 		    $res['ret'] = 0;
             $res['msg'] = "非法请求";
             return $response->getBody()->write(json_encode($res));

--- a/config/.config.php.example
+++ b/config/.config.php.example
@@ -3,6 +3,14 @@
 //  ss-panel-v3-mod_UIChanges配置
 // true为开启，false为关闭
 
+// 注释里请勿使用英文方括号、分号、单引号，否则迁移Config时可能会出现BUG
+
+//config迁移附注（由开发者填写本次config迁移后需要注意的地方，站长勿动）
+//如需换行，直接换行即可，无需换行符
+$System_Config['config_migrate_notice']=
+'enable_prefix和prefix_regex在最近的版本中分别被重命名为enable_flag和flag_regex
+flag_regex在最近的版本中使用了新的值，依然是匹配 国旗名+空格，但效果更好';
+
 
 //基础设置，正确填写以下内容你的网站就能使用了-----------------------------------------------------------------------
 $System_Config['key'] = '1145141919810';			// !!! 瞎 jb 修改此key为随机字符串确保网站安全 !!!


### PR DESCRIPTION
新增：
【1】
一键迁移/更新配置，使用命令：
php /网站目录/xcat migrateConfig
省去了每次更新之后都要自己手动更新config的麻烦
迁移/更新之前会自动备份原config为.config.php.bak
![qy](https://user-images.githubusercontent.com/17256673/41821745-7ffd0e14-7817-11e8-948e-83bb77b0d825.jpg)

【2】部分输入增加了输入检查，输入小数的时候会提示“非法请求”

本次更新如有BUG，请联系
[QQ2576479186]或
[邮箱soda_mail@qq.com]或
[魔改修改版官方TG群@The_DeIc ]
进行修改