### PR TITLE
add port_group

### DIFF
--- a/app/Models/UserMethod.php
+++ b/app/Models/UserMethod.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+class UserMethod extends Model
+{
+    protected $connection = "default";
+    protected $table = "user_method";
+}

--- a/app/Utils/Tools.php
+++ b/app/Utils/Tools.php
@@ -8,6 +8,9 @@ use App\Models\Relay;
 use App\Services\Config;
 use DateTime;
 
+// for port_group
+use App\Models\UserMethod;
+
 class Tools
 {
 
@@ -152,6 +155,14 @@ class Tools
         return $port[0];
     }
 
+    // 根据 $port_group_array 获取端口范围，根据 user_method 表获取已有端口
+    public static function getAvPort_ForPortGroup($port_group_array, $node_id)
+    {
+        $det = UserMethod::where('node_id',$node_id)->pluck('port')->toArray();
+        $port = array_diff(range($port_group_array['min_port'], $port_group_array['max_port']), $det);
+        shuffle($port);
+        return $port[0];
+    }
 
     public static function base64_url_encode($input)
     {

--- a/app/Utils/URL.php
+++ b/app/Utils/URL.php
@@ -5,6 +5,9 @@ use App\Models\Node;
 use App\Models\Relay;
 use App\Services\Config;
 
+// for port_group
+use App\Models\UserMethod;
+
 class URL
 {
     /*
@@ -308,6 +311,24 @@ class URL
     * obfs
     * obfs_param
     */
+
+
+    // for port_group
+    public static function checkPortGroup($user, $node) {
+        $new_user = clone $user;
+        if ($node->port_group == 1) {
+            $u = UserMethod::where('user_id',$user->id)->where('node_id',$node->id)->first();
+            $new_user->port = $u->port;
+            $new_user->passwd = $u->passwd;
+            $new_user->method = $u->method;
+            $new_user->protocol = $u->protocol;
+            $new_user->protocol_param = $u->protocol_param;
+            $new_user->obfs = $u->obfs;
+            $new_user->obfs_param = $u->obfs_param;
+        }
+        return $new_user;
+    }
+
     public static function getItem($user, $node, $mu_port = 0, $relay_rule_id = 0, $is_ss = 0) {
         $relay_rule = Relay::where('id', $relay_rule_id)->where(
             function ($query) use ($user) {
@@ -316,6 +337,10 @@ class URL
             }
         )->first();
         $node_name = $node->name;
+
+        // for port_group
+        $user = URL::checkPortGroup($user, $node);
+
         if ($relay_rule != null) {
             $node_name .= " - ".$relay_rule->dist_node()->name;
         }

--- a/config/routes.php
+++ b/config/routes.php
@@ -108,6 +108,10 @@ $app->group('/user', function () {
     $this->post('/coupon_check', 'App\Controllers\UserController:CouponCheck');
     $this->post('/buy', 'App\Controllers\UserController:buy');
 
+    // for port_group
+    $this->get('/nodeedit', 'App\Controllers\UserController:nodeedit');
+    $this->post('/usermethod', 'App\Controllers\UserController:updateUserMethod');
+    $this->post('/usermethodport', 'App\Controllers\UserController:updateUserMethodPort');
 
     // Relay Mange
     $this->get('/relay', 'App\Controllers\RelayController:index');

--- a/resources/views/material/admin/node/create.tpl
+++ b/resources/views/material/admin/node/create.tpl
@@ -43,7 +43,7 @@
 
 									<div class="form-group form-group-label">
 										<label class="floating-label" for="rate">流量比例</label>
-										<input class="form-control" id="rate" type="text" name="rate">
+										<input class="form-control" id="rate" type="number" name="rate">
 									</div>
 
 									<div class="form-group form-group-label" hidden="hidden">
@@ -122,29 +122,44 @@
 
 									<div class="form-group form-group-label">
 										<label class="floating-label" for="class">节点等级（不分级请填0，分级为数字）</label>
-										<input class="form-control" id="class" type="text" value="0" name="class">
+										<input class="form-control" id="class" type="number" value="0" name="class">
 									</div>
 
 
 									<div class="form-group form-group-label">
 										<label class="floating-label" for="group">节点群组（分组为数字，不分组请填0）</label>
-										<input class="form-control" id="group" type="text" value="0" name="group">
+										<input class="form-control" id="group" type="number" value="0" name="group">
 									</div>
 
+                                    <div class="form-group form-group-label">
+                                        <div class="checkbox switch">
+                                            <label for="port_group">
+                                                <input class="access-hide" id="port_group" name="port_group" type="checkbox"><span class="switch-toggle"></span>启用自定义端口段
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="form-group form-group-label">
+                                        <label class="floating-label" for="min_port">最小端口</label>
+                                        <input class="form-control" id="min_port" name="min_port" type="number" value="1025">
+                                    </div>
+                                    <div class="form-group form-group-label">
+                                        <label class="floating-label" for="max_port">最大端口</label>
+                                        <input class="form-control" id="max_port" name="max_port" type="number" value="65500">
+                                    </div>
 
 									<div class="form-group form-group-label">
 										<label class="floating-label" for="node_bandwidth_limit">节点流量上限（不使用的话请填0）（GB）</label>
-										<input class="form-control" id="node_bandwidth_limit" type="text" value="0" name="node_bandwidth_limit">
+										<input class="form-control" id="node_bandwidth_limit" type="number" value="0" name="node_bandwidth_limit">
 									</div>
 
 									<div class="form-group form-group-label">
 										<label class="floating-label" for="bandwidthlimit_resetday">节点流量上限清空日</label>
-										<input class="form-control" id="bandwidthlimit_resetday" type="text" value="0" name="bandwidthlimit_resetday">
+										<input class="form-control" id="bandwidthlimit_resetday" type="number" value="0" name="bandwidthlimit_resetday">
 									</div>
 
 									<div class="form-group form-group-label">
 										<label class="floating-label" for="node_speedlimit">节点限速(对于每个用户端口)（Mbps）</label>
-										<input class="form-control" id="node_speedlimit" type="text" value="0" name="node_speedlimit">
+										<input class="form-control" id="node_speedlimit" type="number" value="0" name="node_speedlimit">
 									</div>
 								</div>
 							</div>
@@ -229,6 +244,14 @@
 			{
 				var type=0;
 			}
+            if(document.getElementById('port_group').checked)
+            {
+                var port_group=1;
+            }
+            else
+            {
+                var port_group=0;
+            }
 			{/literal}
 			if(document.getElementById('custom_rss').checked)
 			{
@@ -261,7 +284,10 @@
 										node_bandwidth_limit: $("#node_bandwidth_limit").val(),
 										bandwidthlimit_resetday: $("#bandwidthlimit_resetday").val(),
 										custom_rss: custom_rss,
-										mu_only: $("#mu_only").val()
+										mu_only: $("#mu_only").val(),
+                    min_port: $("#min_port").val(),
+                    max_port: $("#max_port").val(),
+                    port_group: port_group
                 },
                 success: function (data) {
                     if (data.ret) {

--- a/resources/views/material/admin/node/edit.tpl
+++ b/resources/views/material/admin/node/edit.tpl
@@ -45,7 +45,7 @@
 
 									<div class="form-group form-group-label">
 										<label class="floating-label" for="rate">流量比例</label>
-										<input class="form-control" id="rate" name="rate" type="text" value="{$node->traffic_rate}">
+										<input class="form-control" id="rate" name="rate" type="number" value="{$node->traffic_rate}">
 									</div>
 
 
@@ -124,28 +124,43 @@
 
 									<div class="form-group form-group-label">
 										<label class="floating-label" for="class">节点等级（不分级请填0，分级为数字）</label>
-										<input class="form-control" id="class" name="class" type="text" value="{$node->node_class}">
+										<input class="form-control" id="class" name="number" type="text" value="{$node->node_class}">
 									</div>
 
 									<div class="form-group form-group-label">
 										<label class="floating-label" for="group">节点群组（分组为数字，不分组请填0）</label>
-										<input class="form-control" id="group" name="group" type="text" value="{$node->node_group}">
+										<input class="form-control" id="group" name="number" type="text" value="{$node->node_group}">
 									</div>
 
+                                    <div class="form-group form-group-label">
+                                        <div class="checkbox switch">
+                                            <label for="port_group">
+                                                <input {if $node->port_group==1}checked{/if} class="access-hide" id="port_group" name="port_group" type="checkbox"><span class="switch-toggle"></span>启用自定义端口段
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="form-group form-group-label">
+                                        <label class="floating-label" for="min_port">最小端口</label>
+                                        <input class="form-control" id="min_port" name="min_port" type="number" value="{$node->min_port}">
+                                    </div>
+                                    <div class="form-group form-group-label">
+                                        <label class="floating-label" for="max_port">最大端口</label>
+                                        <input class="form-control" id="max_port" name="max_port" type="number" value="{$node->max_port}">
+                                    </div>
 
 									<div class="form-group form-group-label">
 										<label class="floating-label" for="node_bandwidth_limit">节点流量上限（不使用的话请填0）（GB）</label>
-										<input class="form-control" id="node_bandwidth_limit" name="node_bandwidth_limit" type="text" value="{$node->node_bandwidth_limit/1024/1024/1024}">
+										<input class="form-control" id="node_bandwidth_limit" name="node_bandwidth_limit" type="number" value="{$node->node_bandwidth_limit/1024/1024/1024}">
 									</div>
 
 									<div class="form-group form-group-label">
 										<label class="floating-label" for="bandwidthlimit_resetday">节点流量上限清空日</label>
-										<input class="form-control" id="bandwidthlimit_resetday" name="bandwidthlimit_resetday" type="text" value="{$node->bandwidthlimit_resetday}">
+										<input class="form-control" id="bandwidthlimit_resetday" name="bandwidthlimit_resetday" type="number" value="{$node->bandwidthlimit_resetday}">
 									</div>
 
 									<div class="form-group form-group-label">
 										<label class="floating-label" for="node_speedlimit">节点限速(对于每个用户端口)（Mbps）</label>
-										<input class="form-control" id="node_speedlimit" name="node_speedlimit" type="text" value="{$node->node_speedlimit}">
+										<input class="form-control" id="node_speedlimit" name="node_speedlimit" type="number" value="{$node->node_speedlimit}">
 									</div>
 								</div>
 							</div>
@@ -227,6 +242,14 @@
 			{
 				var type=0;
 			}
+            if(document.getElementById('port_group').checked)
+            {
+                var port_group=1;
+            }
+            else
+            {
+                var port_group=0;
+            }
 			{/literal}
 			if(document.getElementById('custom_rss').checked)
 			{
@@ -262,7 +285,10 @@
 										node_bandwidth_limit: $("#node_bandwidth_limit").val(),
 										bandwidthlimit_resetday: $("#bandwidthlimit_resetday").val(){/literal},
 										custom_rss: custom_rss,
-										mu_only: $("#mu_only").val()
+										mu_only: $("#mu_only").val(),
+                    min_port: $("#min_port").val(),
+                    max_port: $("#max_port").val(),
+                    port_group: port_group
 					{literal}
                 },
                 success: function (data) {

--- a/resources/views/material/user/main.tpl
+++ b/resources/views/material/user/main.tpl
@@ -391,6 +391,12 @@
 									<i class="icon icon-lg">airplanemode_active</i>&nbsp;节点列表
 								</a>
 							</li>
+                            
+                            <li>
+                                <a href="/user/nodeedit">
+                                    <i class="icon icon-lg">sync_problem</i>&nbsp;节点编辑
+                                </a>
+                            </li>
 
 							<li>
 								<a href="/user/relay">

--- a/resources/views/material/user/nodeedit.tpl
+++ b/resources/views/material/user/nodeedit.tpl
@@ -1,0 +1,183 @@
+
+
+
+{include file='user/main.tpl'}
+
+
+
+
+
+
+
+    <main class="content">
+    
+        <div class="content-header ui-content-header">
+            <div class="container">
+                <h1 class="content-heading">节点编辑</h1>
+            </div>
+        </div>
+        
+        <div class="container">
+        <section class="content-inner margin-top-no">
+
+{if $nodes ==0}
+                        <div class="card margin-bottom-no">
+                            <div class="card-main">
+                                <div class="card-inner">
+                                    <div class="card-inner">
+                                        <p class="card-heading">暂无相关节点</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+    {include file='dialog.tpl'}
+
+        </section>
+        </div>
+
+    </main>
+
+    {include file='user/footer.tpl'}
+
+{else}
+
+                        <div class="card margin-bottom-no">
+                            <div class="card-main">
+                                <div class="card-inner">
+                                    <div class="card-inner">
+                                        <p class="card-heading">修改须知</p>
+                                        <p>若是设置了中转，则加密、混淆、协议和密码等等都以终点服务器为准！</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+    {foreach $usermethods as $usermethod}
+    {foreach $nodes as $node}
+    {if $usermethod->node_id == $node->id}
+
+                        <div class="card margin-bottom-no">
+                            <div class="card-main">
+
+                                <div class="card-inner">
+
+                                        <p class="card-heading">{$node->name}</p>
+                                        <div class="card-action-btn pull-left" style="width:100%">
+                                        <p>当前端口：{$usermethod->port}    <button class="btn btn-flat waves-attach" id="ssr-node-{$node->id}-port" ><span class="icon">check</span>&nbsp;重置端口</button></p>
+                                            
+                                        </div>
+                                        <div class="form-group form-group-label" style="display:none">
+                                            <select id="node_id-node-{$node->id}" class="form-control">
+                                            <option value="{$node->id}" >{$node->name}</option>
+                                            </select>
+                                        </div>
+
+                                        <div class="form-group form-group-label" style="float:left;width:220px">
+                                            <label class="floating-label" for="sspwd">连接密码 当前密码：{$usermethod->passwd}</label>
+                                            <input class="form-control" id="sspwd-node-{$node->id}" type="password" value="{$usermethod->passwd}">
+                                        </div>
+                                        
+                                        <div class="form-group form-group-label" style="float:left;width:220px">
+                                            <label class="floating-label" for="method">加密方式</label>
+                                            <select id="method-node-{$node->id}" class="form-control">
+                                            {foreach $method_list as $method}   <option value="{$method}" {if $usermethod->method == $method}selected="selected"{/if}>[{if URL::CanMethodConnect($method) == 2}SS{else}SS/SSR{/if} 可连接] {$method}</option>
+                                            {/foreach}</select>
+                                        </div>
+                                        <div class="form-group form-group-label" style="float:left;width:220px">
+                                            <label class="floating-label" for="protocol">协议</label>
+                                            <select id="protocol-node-{$node->id}" class="form-control">
+                                            {foreach $protocol_list as $protocol}   <option value="{$protocol}" {if $usermethod->protocol == $protocol}selected="selected"{/if}>[{if URL::CanProtocolConnect($protocol) == 3}SS/SSR{else}SSR{/if} 可连接] {$protocol}</option>
+                                            {/foreach}</select>
+                                        </div>
+                                        <div class="form-group form-group-label" style="float:left;width:220px">
+                                            <label class="floating-label" for="obfs">混淆</label>
+                                            <select id="obfs-node-{$node->id}" class="form-control">
+                                            {foreach $obfs_list as $obfs}   <option value="{$obfs}" {if $usermethod->obfs == $obfs}selected="selected"{/if}>[{if URL::CanObfsConnect($obfs) >= 3}SS/SSR{else}{if URL::CanObfsConnect($obfs) == 1}SSR{else}SS{/if}{/if} 可连接] {$obfs}</option>
+                                            {/foreach}</select>
+                                        </div>
+
+                                </div>
+                                <div class="card-action">
+                                    <div class="card-action-btn pull-left">
+                                        <button class="btn btn-flat waves-attach" id="ssr-node-{$node->id}" ><span class="icon">check</span>&nbsp;提交</button>
+                                    </div>
+                                </div>
+                                    
+                            </div>
+                        </div>
+    {/if}
+    {/foreach}
+    {/foreach}
+
+    {include file='dialog.tpl'}
+
+        </section>
+        </div>
+
+    </main>
+
+    {include file='user/footer.tpl'}
+
+    {foreach $nodes as $node}
+    <script>
+        $(document).ready(function () {
+            $("#ssr-node-{$node->id}").click(function () {
+                $.ajax({
+                    type: "POST",
+                    url: "usermethod",
+                    dataType: "json",
+                    data: {
+                        node_id: $("#node_id-node-{$node->id}").val(),
+                        method: $("#method-node-{$node->id}").val(),
+                        sspwd: $("#sspwd-node-{$node->id}").val(),
+                        protocol: $("#protocol-node-{$node->id}").val(),
+                        obfs: $("#obfs-node-{$node->id}").val()
+                    },
+                    success: function (data) {
+                        if (data.ret) {
+                            $("#result").modal();
+                            $("#msg").html(data.msg);
+                        } else {
+                            $("#result").modal();
+                            $("#msg").html(data.msg);
+                        }
+                    },
+                    error: function (jqXHR) {
+                        $("#result").modal();
+                        $("#msg").html(data.msg+"     出现了一些错误。");
+                    }
+                })
+            })
+        })
+    </script>
+    <script>
+        $(document).ready(function () {
+            $("#ssr-node-{$node->id}-port").click(function () {
+                $.ajax({
+                    type: "POST",
+                    url: "usermethodport",
+                    dataType: "json",
+                    data: {
+                        node_id: $("#node_id-node-{$node->id}").val(),
+                        port: $("#port-node-{$node->id}").val()
+                    },
+                    success: function (data) {
+                        if (data.ret) {
+                            $("#result").modal();
+                            $("#msg").html(data.msg);
+                        } else {
+                            $("#result").modal();
+                            $("#msg").html(data.msg);
+                        }
+                    },
+                    error: function (jqXHR) {
+                        $("#result").modal();
+                        $("#msg").html(data.msg+"     出现了一些错误。");
+                    }
+                })
+            })
+        })
+    </script>
+    {/foreach}
+
+{/if}

--- a/sql/port_group.sql
+++ b/sql/port_group.sql
@@ -1,0 +1,17 @@
+ALTER TABLE `ss_node` ADD column `port_group` int(3) NOT NULL DEFAULT '0';
+ALTER TABLE `ss_node` ADD column `min_port` int(11) NOT NULL DEFAULT '1025';
+ALTER TABLE `ss_node` ADD column `max_port` int(11) NOT NULL DEFAULT '65500';
+
+CREATE TABLE `user_method` (
+    `id` int(11) NOT NULL AUTO_INCREMENT,
+    `user_id` int(11) NOT NULL,
+    `node_id` int(11) NOT NULL,
+    `port` int(11) NOT NULL,
+    `passwd` varchar(16) NOT NULL,
+    `method` varchar(64) NOT NULL DEFAULT 'chacha-20',
+    `protocol` varchar(128) DEFAULT 'origin',
+    `protocol_param` varchar(128) DEFAULT '',
+    `obfs` varchar(128) DEFAULT 'plain',
+    `obfs_param` varchar(128) DEFAULT '',
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
本次commit内容为新增自定义端口段，后端可从 `user_method` 表获取用户数据

一、mysql变动说明
0、文件在 sql/port_group.sql
1、新建 `user_mehod` 表，
2、对  `ss_node` 表新增 `port_group` `min_port` `max_port` 等字段，其中 `port_group` 默认为0，启用自定义端口段则为1

二、管理员界面、用户界面及订阅的相关更新
经本地测试，未找到明显的问题，可正常使用

三、一些声明
1、port_group 仅会在 节点类型为 ss——即 0，9，10时启用，其余类型不受干扰
2、port_group 为 0 ，则与 uim 原版兼容，功能无差异；为 1 时，单端口等设置未经测试。
3、中转功能及相应后端会在后期进行更新，关注 https://github.com/010ada 即可