### PR TITLE
修正一个判断错误

### DIFF
--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -744,7 +744,7 @@ class UserController extends BaseController
 
                 array_push($node_prefix[$name_cheif], $node);
 
-				if(Config::get('enable_flag')==true){
+				if(Config::get('enable_flag')=="true"){
 					$regex=Config::get('flag_regex');
 					$matches=array();
 					preg_match($regex,$name_cheif,$matches);

--- a/app/Utils/Update.php
+++ b/app/Utils/Update.php
@@ -100,7 +100,7 @@ class Update
 			)+1
 		);
 		echo('以下是迁移附注：');
-		if(isset($System_Config['config_migrate_notice'])==true){
+		if(isset($System_Config['config_migrate_notice'])){
 		    if($System_Config['config_migrate_notice']!=$notice_new){
 			    echo($notice_new);
 			}


### PR DESCRIPTION
```php
var_dump(Config::get('enable_flag')); // string "false"
var_dump(Config::get('enable_flag') == true); // boolean true
var_dump(Config::get('enable_flag') == "true"); // boolean false
```

在 PHP 7.2.6 上测试

并且去掉了一个没有必要的 `==true`