### PR TITLE
Refactor: remove jquery.qrcode

### DIFF
--- a/resources/views/material/auth/login.tpl
+++ b/resources/views/material/auth/login.tpl
@@ -244,12 +244,12 @@
 </script>
 
 {if $config['enable_telegram'] == 'true'}
-    <script src=" /assets/public/js/jquery.qrcode.min.js "></script>
+    <script src="https://cdn.jsdelivr.net/gh/davidshimjs/qrcodejs@gh-pages/qrcode.min.js"></script>
     <script>
         var telegram_qrcode = 'mod://login/{$login_token}';
-        jQuery('#telegram-qr').qrcode({
-            "text": telegram_qrcode
-        });
+        var qrcode = new QRCode(document.getElementById("telegram-qr"));
+        qrcode.clear();
+        qrcode.makeCode(telegram_qrcode);
     </script>
     <script>
         $(document).ready(function () {

--- a/resources/views/material/auth/login.tpl
+++ b/resources/views/material/auth/login.tpl
@@ -289,8 +289,8 @@
 
                         } else {
                             if (data.ret == -1) {
-                                jQuery('#telegram-qr').replaceWith('此二维码已经过期，请刷新页面后重试。');
-                                jQuery('#code_number').replaceWith('<code id="code_number">此数字已经过期，请刷新页面后重试。</code>');
+                                $('#telegram-qr').replaceWith('此二维码已经过期，请刷新页面后重试。');
+                                $('#code_number').replaceWith('<code id="code_number">此数字已经过期，请刷新页面后重试。</code>');
                             }
                         }
                     },

--- a/resources/views/material/user/code.tpl
+++ b/resources/views/material/user/code.tpl
@@ -156,8 +156,6 @@
         </section>
     </div>
 </main>
-<script src="/assets/js/jquery.min.js"></script>
-<script src="https://cdn.jsdelivr.net/gh/davidshimjs/qrcodejs@gh-pages/qrcode.min.js"></script>
 <script>
 	$(document).ready(function () {
 		$("#code-update").click(function () {

--- a/resources/views/material/user/doiam.tpl
+++ b/resources/views/material/user/doiam.tpl
@@ -35,12 +35,12 @@
 <script>
 	var type = "wepay";
 	var pid = 0;
-window.onload = function(){
-	$('body').append("<script src=\" \/assets\/public\/js\/jquery.qrcode.min.js \"><\/script>");
+window.onload = function() {
+    var qrcode = new QRCode(document.getElementById("dmy"));
 	$(".type").click(function(){
 		type = $(this).data("pay");
 	});
-    type= 'alipay'
+    type = 'alipay';
 	$("#submit").click(function(){
 		var price = parseFloat($("#amount").val());
 		console.log("将要使用"+type+"方法充值"+price+"元");
@@ -67,9 +67,8 @@ window.onload = function(){
 					if(type=="wepay"){
 						$("#result").modal();
 						$("#msg").html('<div class="text-center">使用微信扫描二维码支付.<div id="dmy" style="padding-top:  10px;"></div></div>');
-						$("#dmy").qrcode({
-							"text": data.code
-						});
+                        qrcode.clear();
+                        qrcode.makeCode(data.code);
                         setTimeout(f, 2000);
 					}else if(type=="alipay"){
 						$("#result").modal();
@@ -77,9 +76,8 @@ window.onload = function(){
 					}else if(type=="qqpay"){
 						$("#result").modal();
 						$("#msg").html('<div class="text-center">使用QQ扫描二维码支付.<div id="dmy"></div></div>');
-						$("#dmy").qrcode({
-							"text": data.code
-						});
+                        qrcode.clear();
+                        qrcode.makeCode(data.code);
                         setTimeout(f, 2000);
 					}
 				}

--- a/resources/views/material/user/edit.tpl
+++ b/resources/views/material/user/edit.tpl
@@ -539,19 +539,17 @@ $(".copy-text").click(function () {
     })
 </script>
 
-<script src=" /assets/public/js/jquery.qrcode.min.js "></script>
 <script>
-	var ga_qrcode = '{$user->getGAurl()}';
-	jQuery('#ga-qr').qrcode({
-		"text": ga_qrcode
-	});
+	var ga_qrcode = '{$user->getGAurl()}',
+        qrcode1 = new QRCode(document.getElementById("ga-qr"));
+    qrcode1.clear();
+    qrcode1.makeCode(ga_qrcode);
 
 	{if $config['enable_telegram'] == 'true'}
-	var telegram_qrcode = 'mod://bind/{$bind_token}';
-	jQuery('#telegram-qr').qrcode({
-		"text": telegram_qrcode
-	});
-	{/if}
+	var telegram_qrcode = 'mod://bind/{$bind_token}',
+        qrcode2 = new QRCode(document.getElementById("telegram-qr"));
+    qrcode2.clear();
+    qrcode2.makeCode(telegram_qrcode);
 </script>
 
 

--- a/resources/views/material/user/nodeinfo.tpl
+++ b/resources/views/material/user/nodeinfo.tpl
@@ -312,25 +312,26 @@
 {include file='user/footer.tpl'}
 
 
-<script src="/assets/public/js/jquery.qrcode.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/davidshimjs/qrcodejs@gh-pages/qrcode.min.js"></script>
 <script>
 	{if URL::SSCanConnect($user, $mu)}
-	var text_qrcode = '{URL::getItemUrl($ss_item, 1)}';
-	jQuery('#ss-qr').qrcode({
-		"text": text_qrcode
-	});
+    var text_qrcode = '{URL::getItemUrl($ss_item, 1)}',
+        text_qrcode_win = '{URL::getItemUrl($ss_item, 2)}';
 
-	var text_qrcode_win = '{URL::getItemUrl($ss_item, 2)}';
-	jQuery('#ss-qr-win').qrcode({
-		"text": text_qrcode_win
-	});
+    var qrcode1 = new QRCode(document.getElementById("ss-qr")),
+        qrcode2 = new QRCode(document.getElementById("ss-qr"));
+
+    qrcode1.clear();
+    qrcode1.makeCode(text_qrcode);
+    qrcode2.clear();
+    qrcode2.makeCode(text_qrcode_win);
 	{/if}
 
 	{if URL::SSRCanConnect($user, $mu)}
-	var text_qrcode2 = '{URL::getItemUrl($ssr_item, 0)}';
-	jQuery('#ss-qr-n').qrcode({
-		"text": text_qrcode2
-	});
+    var text_qrcode2 = '{URL::getItemUrl($ssr_item, 0)}';
+    var qrcode3 = new QRCode(document.getElementById("ss-qr-n"));
+    qrcode3.clear();
+    qrcode3.makeCode(text_qrcode2);
 	{/if}
 
 


### PR DESCRIPTION
Replace all of `jquery.qrcode` and its function with `qrcodejs` one.

This PR is related to issue #373, and may contains BREAKING CHANGES.