### PR TITLE
Feat/CI: add tests for xcat command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,6 @@ before_script:
 script:
   - sudo cp config/.config.php.example config/.config.php
   - phplint '**/*.php' '!vendor/**'
+  - sudo php xcat update
+  - sudo php xcat initQQWry
+  - sudo php xcat initdownload


### PR DESCRIPTION
Now CI will run those commands during testing:

- `sudo php xcat update`
- `sudo php xcat initQQWry`
- `sudo php xcat initdownload`

> As Travis CI doesn't provide root user permission so I have to run in `sudo` mode. Most commands can still run without any problem.