### PR TITLE
适配v2rayN,关于ws+tls情况下的格式. 和clash的生成逻辑保持一致

### DIFF
--- a/app/Utils/URL.php
+++ b/app/Utils/URL.php
@@ -375,8 +375,13 @@ class URL
                 $item['tls'] = 'tls';
             }
         }
-        if (count($node_explode) >= 5 and in_array($item['net'], array("kcp", "http"))) {
-            $item['type'] = $node_explode[4];
+        if (count($node_explode) >= 5 ) {
+            if (in_array($item['net'], array("kcp", "http"))){
+
+                $item['type'] = $node_explode[4];
+            } else if ($node_explode[4]=='ws'){
+                $item['net'] = 'ws';
+            }
         }
 
         if (count($node_explode) >= 6) {


### PR DESCRIPTION
遵循项目Wiki v2ray使用教程里的节点地址填写规范，适配了v2rayN 目前在使用的[分享链接格式 2.0](https://github.com/2dust/v2rayN/wiki/%E5%88%86%E4%BA%AB%E9%93%BE%E6%8E%A5%E6%A0%BC%E5%BC%8F%E8%AF%B4%E6%98%8E(ver-2))。 2.0的分享格式中，tls不在作为net的value。  并和getClashInfo的代码逻辑保持一致。 