### PR TITLE
增加了Clash 首页展示和订阅链接展示。

### DIFF
--- a/app/Utils/URL.php
+++ b/app/Utils/URL.php
@@ -148,6 +148,13 @@ class URL
                 }
             }
 
+            if (count($node_explode) >= 6) {
+                $docs = array_merge($docs, URL::parse_args($node_explode[5]));
+            }
+            if (array_key_exists('path',$docs)){
+                $docs['ws-path'] = $docs['path'];
+                unset($docs['path']);
+            }
             $result[] = $docs;
         }
 

--- a/resources/conf/clash.tpl
+++ b/resources/conf/clash.tpl
@@ -43,9 +43,9 @@ Rule:
 ## IQIYI
 - DOMAIN-KEYWORD,qiyi,{config::get("appName")}
 - DOMAIN-SUFFIX,qy.net,{config::get("appName")}
-- IP-CIDR,101.227.0.0/16,{config::get("appName")},no-resolve
-- IP-CIDR,101.224.0.0/13,{config::get("appName")},no-resolve
-- IP-CIDR,119.176.0.0/12,{config::get("appName")},no-resolve
+- IP-CIDR,101.227.0.0/16,{config::get("appName")}
+- IP-CIDR,101.224.0.0/13,{config::get("appName")}
+- IP-CIDR,119.176.0.0/12,{config::get("appName")}
 
 ## letv
 - DOMAIN-SUFFIX,api.mob.app.letv.com,{config::get("appName")}
@@ -64,7 +64,7 @@ Rule:
 - DOMAIN-SUFFIX,vv.video.qq.com,{config::get("appName")}
 
 ## Youku
-- IP-CIDR,106.11.0.0/16,{config::get("appName")},no-resolve
+- IP-CIDR,106.11.0.0/16,{config::get("appName")}
 
 
 

--- a/resources/conf/clash.tpl
+++ b/resources/conf/clash.tpl
@@ -8,7 +8,9 @@ external-controller: '0.0.0.0:9090'
 secret: ''
 Proxy:
 {foreach $confs as $conf}
-  - {$conf|json_encode}
+
+    - {json_encode($conf,JSON_UNESCAPED_SLASHES)}
+
 {/foreach}
 
 'Proxy Group':

--- a/resources/views/material/user/index.tpl
+++ b/resources/views/material/user/index.tpl
@@ -181,6 +181,9 @@
 												<li>
 													<a class="waves-attach" data-toggle="tab" href="#all_v2ray"><i class="icon icon-lg">flight_land</i>&nbsp;V2RAY</a>
 												</li>
+												<li>
+													<a class="waves-attach" data-toggle="tab" href="#all_clash"><i class="icon icon-lg">flight</i>&nbsp;CLASH</a>
+												</li>
 											</ul>
 										</nav>
 										<div class="card-inner">
@@ -490,6 +493,36 @@
 													</div>
 													<div class="tab-pane fade" id="all_v2ray_windows">
 														<a href="/ssr-download/Clash-Windows.7z" class="btn-dl"><i class="material-icons">save_alt</i> 点击下载 ClashX</a>
+													</div>
+												</div>
+												<div class="tab-pane fade" id="all_clash">
+													<nav class="tab-nav margin-top-no">
+														<ul class="nav nav-list">
+															<li class="active">
+																<a class="waves-attach" data-toggle="tab" href="#all_clash_info"><i class="icon icon-lg">info_outline</i>&nbsp;连接信息</a>
+															</li>
+															<li>
+																<a class="waves-attach" data-toggle="tab" href="#all_clash_windows"><i class="icon icon-lg">desktop_windows</i>&nbsp;Windows</a>
+															</li>
+															<li>
+																<a class="waves-attach" data-toggle="tab" href="#all_clash_mac"><i class="icon icon-lg">laptop_mac</i>&nbsp;Mac</a>
+															</li>
+														</ul>
+													</nav>
+													<div class="tab-pane fade active in" id="all_clash_info">
+														<div><span class="icon icon-lg text-white">flash_auto</span> CLASH配置文件订阅地址：</div>
+														<div class="float-clear"><input type="text" class="input form-control form-control-monospace cust-link col-xx-12 col-sm-8 col-lg-7" name="input1" readonly value="{$subUrl}{$ssr_sub_token}?mu=4" readonly="true" />
+															<button class="copy-text btn btn-subscription col-xx-12 col-sm-3 col-lg-2" type="button" data-clipboard-text="{$subUrl}{$ssr_sub_token}?mu=4">
+																点击复制
+															</button>
+															<br>
+														</div>
+													</div>
+													<div class="tab-pane fade" id="all_clash_windows">
+														<a href="/ssr-download/Clash-Windows.7z" class="btn-dl"><i class="material-icons">save_alt</i> 点击下载 Clash for Windows</a>
+													</div>
+													<div class="tab-pane fade" id="all_clash_mac">
+														<a href="/ssr-download/ClashX.dmg" class="btn-dl"><i class="material-icons">save_alt</i> 点击下载 ClashX</a>
 													</div>
 												</div>
 											</div>


### PR DESCRIPTION
1. 增加Clash 首页展示，clashX 和 clash for windows 客户端下载链接。
2. 修改getClashInfo， 增加额外参数的解析。 适配clash的path key是ws-path。 考虑到会有节点隐藏在cdn背后，前端(我可能错误）无法获取cdn后的真实ip地址，造成第一个域名填写cdn域名时，后端由于无法匹配数据库ip而无法正常获取数据（webapi）。 通过增加额外参数解析，允许在URL产生过程中， 重写server的值。 比如 ws+tls的配置可以写成: 未cdn域名;端口;alterId;tls;ws;path=/v2ray|server=cdn域名。 不加tls的格式: 未cdn域名;端口;alterId;ws;tls;path=/v2ray|server=cdn域名
3. 适配现在clash，rules 不再使用force-remote-dns,no-reslove 等参数的情况。
